### PR TITLE
:sparkles: - Allow regex pre-filter for compilation

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -815,7 +815,7 @@ pub fn compile_file(
 
 pub fn clean(path: &str) {
     let project_root = helpers::get_abs_path(path);
-    let packages = package_tree::make(&project_root);
+    let packages = package_tree::make(&None, &project_root);
 
     packages.iter().for_each(|(_, package)| {
         println!("Cleaning {}...", package.name);
@@ -852,7 +852,10 @@ fn compute_file_hash(path: &str) -> Option<blake3::Hash> {
     }
 }
 
-pub fn build(path: &str) -> Result<AHashMap<std::string::String, Module>, ()> {
+pub fn build(
+    filter: &Option<regex::Regex>,
+    path: &str,
+) -> Result<AHashMap<std::string::String, Module>, ()> {
     let timing_total = Instant::now();
     let project_root = helpers::get_abs_path(path);
     let rescript_version = get_version(&project_root);
@@ -864,7 +867,7 @@ pub fn build(path: &str) -> Result<AHashMap<std::string::String, Module>, ()> {
     );
     let _ = stdout().flush();
     let timing_package_tree = Instant::now();
-    let packages = package_tree::make(&project_root);
+    let packages = package_tree::make(&filter, &project_root);
     let timing_package_tree_elapsed = timing_package_tree.elapsed();
     logs::initialize(&packages);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
+use regex::Regex;
 pub mod bsconfig;
 pub mod build;
-pub mod logs;
-pub mod clean;
 pub mod build_types;
+pub mod clean;
 pub mod grouplike;
 pub mod helpers;
+pub mod logs;
 pub mod package_tree;
 pub mod structure_hashmap;
 pub mod watcher;
@@ -13,19 +14,23 @@ fn main() {
     env_logger::init();
     let command = std::env::args().nth(1).unwrap_or("build".to_string());
     let folder = std::env::args().nth(2).unwrap_or(".".to_string());
+    let filter = std::env::args()
+        .nth(3)
+        .map(|filter| Regex::new(filter.as_ref()).expect("Could not parse regex"));
+
     match command.as_str() {
         "clean" => {
             build::clean(&folder);
         }
         "build" => {
-            match build::build(&folder) {
+            match build::build(&filter, &folder) {
                 Err(()) => std::process::exit(1),
                 Ok(_) => std::process::exit(0),
             };
         }
         "watch" => {
-            let _modules = build::build(&folder);
-            watcher::start(&folder);
+            let _modules = build::build(&filter, &folder);
+            watcher::start(&filter, &folder);
         }
         _ => println!("Not a valid build command"),
     }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -29,15 +29,24 @@ pub fn start(filter: &Option<regex::Regex>, folder: &str) {
                     .iter()
                     .filter_map(|event| {
                         let path_buf = event.path.to_path_buf();
+                        let name = path_buf
+                            .file_name()
+                            .and_then(|x| x.to_str())
+                            .unwrap_or("Unknown")
+                            .to_string();
                         let extension = path_buf.extension().and_then(|ext| ext.to_str());
-                        if let Some(extension) = extension {
-                            if FILE_EXTENSIONS.contains(&extension) {
+
+                        match extension {
+                            Some(extension)
+                                if filter
+                                    .as_ref()
+                                    .map(|re| !re.is_match(&name))
+                                    .unwrap_or(true)
+                                    && FILE_EXTENSIONS.contains(&extension) =>
+                            {
                                 Some(path_buf)
-                            } else {
-                                None
                             }
-                        } else {
-                            None
+                            _ => None,
                         }
                     })
                     .collect::<Vec<PathBuf>>();

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 pub static FILE_EXTENSIONS: &[&str] = &["re", "res", "ml", "mli", "rei", "resi"];
 
-pub fn start(folder: &str) {
+pub fn start(filter: &Option<regex::Regex>, folder: &str) {
     let (tx, rx) = std::sync::mpsc::channel();
 
     let mut debouncer = new_debouncer_opt::<_, notify::RecommendedWatcher>(
@@ -43,7 +43,7 @@ pub fn start(folder: &str) {
                     .collect::<Vec<PathBuf>>();
 
                 if paths.len() > 0 {
-                    let _ = build::build(&folder);
+                    let _ = build::build(&filter, &folder);
                 }
             }
             Err(_) => (),


### PR DESCRIPTION
This adds a third positional argument to filter out some files using a regex.

For the mono-repo, filtering out Stories and tests from compiling every time saves me about 4 seconds of parsing, and 4 seconds of compiling with a fresh build.