### PR TITLE
:bug: - Fix namespace function to preserve all caps namespaces

### DIFF
--- a/src/package_tree.rs
+++ b/src/package_tree.rs
@@ -140,6 +140,7 @@ fn build_package<'a>(
                 None => None,
                 Some(bsconfig::Namespace::String(str)) => match str.as_str() {
                     "true" => Some(namespace_from_package_name(&bsconfig.name)),
+                    namespace if namespace.is_case(Case::UpperFlat) => Some(namespace.to_string()),
                     namespace => Some(namespace.to_string().to_case(Case::Pascal)),
                 },
             },


### PR DESCRIPTION
According to the [corresponding conversion function in the `rescript-compiler` repo](https://github.com/rescript-lang/rescript-compiler/blob/8bac19ea4da2e4792e0064bf407fc129e7a7cbbf/jscomp/ext/ext_namespace.ml#L70), namespaces that are ALL CAPS will be preserved (in contrast to npm package names). 

I put it in the [Reason playground](https://reasonml.github.io/en/try?rrjsx=true&reason=LYewJgrgNgpgBAUQB4BcD6AjCAzbMBOcAvHAN4BQccKAngA7wrFmVVzAQoCGGscWuAgC5+NFDADOAGlZUO3XvDogJASxSqQAOxGqtKGW3acefWFoDmKABa79huAF8A3OVawmAY3wwu45lrEAHwsRh5wgSSBADxwAIxwAPzxcCJarmEwTBLMAEJikgB03r7iABRaAJQZbKQCePgi0nDKahraIgAMUnDmVrYRLqxD7llwntri+jkkGMFw+eIShRIQGGgSKPh6FmUYhfUEPd38ha3qmlWuo0w+agBe8CR7PaA+lfMUmUzmzPt9NhqVHCWhgAHc0L8SD5sGVzNVZHAwdZVHw9mcVBdtHAANTsEA+OAhUEQ8wAPQ+XyMEXBkJggSEJAATHAAFQ00n0slApw8kG0w6EEiLIolPwwCq08kIowi5a8dTowXHHokzA4Boq07ndpXRH7QUBAUagg8-70-pGzlabmIrgSCQEFDonWXXH4wnRWaFAHWGW8tzAsZcMBgNCeaxcIVwF7jD5EEJUoNMVp-DFtS481TYGOpoLe32UxFUO6qR6xuL+qhDWUFZYQLQSLh4DZZJUm-A9Vo9TxV7WY3XMVN4uI1IYjEFcYCSOhcTwwNAgbBoWeeADWXAsC60U6eMYkTS2O0qh+2lk+N169OYAGUj5YfRabGUJP7wgJmMh0ILij5xXD6TfYNQ2YMpPC4Oh1C4KAez9YJES-dVBHwQoQzDCMoz2HAewgqCoCSOAAGFIxQiA6AYfBwMdNB7U8VRVDAuCRAjBFLx8Tw4C4CAkFA8DIO4GC4CXbAenheCjGzGNhLgWIxKTNhwgjW97wsQoGybFst2dZphL7KgJDBdQlMYotqTgAAfOAAHIuCswpCis+4rOLCzrIAQTshyAC1nLMyyrM6TyrIATl86l-LQKzxLMzjQzA3CBNgvS2C4pAymwaDHR6aSR1EwCeSofyAHowqMfyAFoooTTjuLKLYIBgbLcHdOI8qqFzLLQeZUvi-joKanNcqvdqzJrNgRioHr6sauATnhGpEJ-CZ9HpFAJCw7AERGABtczWAAIjcgAZI7CLcgAFG99ocfaJB3NcYHKqiYGug7CIS6CyxgMBXqofbzto6D3sdX64EOqAABUYAAJS0NyUAASS0ABxUH9sMmw4AkVdJH4LIwRgek0YQAA3BB8AATRQAAJVQADkLB6GASYIGhkQIGbjqOwpOIhnoAHktHnV7zIAXXIcqglyGAoBQQo3PwfAuBoQpsAJBA52sCoZmJXdsbnBclxXOcNy3NAd2nbXKklgApZYoBACwESAA) to check the different outputs, I guess this PR won't fix every possible namespace, but the other combinations are nothing that I encountered in the real world.