### PR TITLE
Extend build.rs calls to bsc with jsx, uncurried, warnings and file suffixes

### DIFF
--- a/CompilerConfigurationSpec.md
+++ b/CompilerConfigurationSpec.md
@@ -1,0 +1,169 @@
+## ReScript build configuration
+
+This document contains a list of all bsconfig parameters with remarks, and whether they are already implemented in rewatch. It is based on https://rescript-lang.org/docs/manual/latest/build-configuration-schema.
+
+| Parameter            | JSON type               | Remark | Implemented? |
+| -------------------- | ----------------------- | ------ | :----------: |
+| version              | string                  |        |     [_]      |
+| name                 | string                  |        |     [x]      |
+| namespace            | boolean                 |        |     [x]      |
+| namespace            | string                  |        |     [x]      |
+| sources              | string                  |        |     [x]      |
+| sources              | array of string         |        |     [x]      |
+| sources              | Source                  |        |     [x]      |
+| sources              | array of Source         |        |     [x]      |
+| ignored-dirs         | array of string         |        |     [_]      |
+| bs-dependencies      | array of string         |        |     [x]      |
+| bs-dev-dependencies  | array of string         |        |     [x]      |
+| pinned-dependencies  | array of string         |        |     [x]      |
+| generators           | array of Rule-Generator |        |     [_]      |
+| cut-generators       | boolean                 |        |     [_]      |
+| jsx                  | JSX                     |        |     [x]      |
+| uncurried            | boolean                 |        |     [x]      |
+| reason               | Reason                  |        |     [x]      |
+| gentypeconfig        | Gentype                 |        |     [_]      |
+| bsc-flags            | array of string         |        |     [x]      |
+| warnings             | Warnings                |        |     [x]      |
+| ppx-flags            | array of string         |        |     [x]      |
+| pp-flags             | array of string         |        |     [_]      |
+| js-post-build        | Js-Post-Build           |        |     [_]      |
+| package-specs        | array of Module-Format  |        |     [_]      |
+| package-specs        | array of Package-Spec   |        |     [x]      |
+| entries              | array of Target-Item    |        |     [_]      |
+| use-stdlib           | boolean                 |        |     [_]      |
+| external-stdlib      | string                  |        |     [_]      |
+| bs-external-includes | array of string         |        |     [_]      |
+| suffix               | Suffix                  |        |     [x]      |
+| reanalyze            | Reanalyze               |        |     [_]      |
+
+### Source
+
+| Parameter        | JSON type                | Remark | Implemented? |
+| ---------------- | ------------------------ | ------ | :----------: |
+| dir              | string                   |        |     [x]      |
+| type             | "dev"                    |        |     [x]      |
+| files            | array of string          |        |     [_]      |
+| files            | File-Object              |        |     [_]      |
+| generators       | array of Build-Generator |        |     [_]      |
+| public           | "all"                    |        |     [_]      |
+| public           | array of string          |        |     [_]      |
+| resources        | array of string          |        |     [_]      |
+| subdirs          | boolean                  |        |     [x]      |
+| subdirs          | string                   |        |     [_]      |
+| subdirs          | array of string          |        |     [x]      |
+| subdirs          | Source                   |        |     [_]      |
+| subdirs          | array of Source          |        |     [x]      |
+| group            | string                   |        |     [_]      |
+| group            | Group                    |        |     [_]      |
+| internal-depends | array of string          |        |     [_]      |
+
+### File-Object
+
+| Parameter | JSON type       | Remark | Implemented? |
+| --------- | --------------- | ------ | :----------: |
+| slow-re   | string          |        |     [_]      |
+| excludes  | array of string |        |     [_]      |
+
+### Build-Generator
+
+| Parameter | JSON type       | Remark | Implemented? |
+| --------- | --------------- | ------ | :----------: |
+| name      | string          |        |     [_]      |
+| edge      | array of string |        |     [_]      |
+
+### Rule-Generator
+
+| Parameter | JSON type | Remark | Implemented? |
+| --------- | --------- | ------ | :----------: |
+| name      | string    |        |     [_]      |
+| command   | string    |        |     [_]      |
+
+### JSX
+
+| Parameter       | JSON type       | Remark | Implemented? |
+| --------------- | --------------- | ------ | :----------: |
+| version         | JSX-Version     |        |     [x]      |
+| module          | "react"         |        |     [x]      |
+| mode            | JSX-Mode        |        |     [x]      |
+| v3-dependencies | array of string |        |     [x]      |
+
+### JSX-Version
+
+enum: 3 | 4
+
+### JSX-Mode
+
+enum: "classic" | "automatic"
+
+### Gentype
+
+| Parameter | JSON type | Remark | Implemented? |
+| --------- | --------- | ------ | :----------: |
+| path      | string    |        |     [_]      |
+
+### Reanalyze
+
+| Parameter  | JSON type                   | Remark | Implemented? |
+| ---------- | --------------------------- | ------ | :----------: |
+| analysis   | array of Reanalyze-Analysis |        |     [_]      |
+| suppress   | array of string             |        |     [_]      |
+| unsuppress | array of string             |        |     [_]      |
+| transitive | boolean                     |        |     [_]      |
+
+### Reanalyze-Analysis
+
+enum: | "dce" | "exception" | "termination"
+
+### Warnings
+
+| Parameter | JSON type | Remark | Implemented? |
+| --------- | --------- | ------ | :----------: |
+| number    | string    |        |     [x]      |
+| error     | boolean   |        |     [x]      |
+| error     | string    |        |     [x]      |
+
+### Js-Post-Build
+
+| Parameter | JSON type | Remark | Implemented? |
+| --------- | --------- | ------ | :----------: |
+| cmd       | string    |        |     [_]      |
+
+### Package-Spec
+
+| Parameter | JSON type     | Remark | Implemented? |
+| --------- | ------------- | ------ | :----------: |
+| module    | Module-Format |        |     [x]      |
+| in-source | boolean       |        |     [x]      |
+| suffix    | Suffix        |        |     [_]      |
+
+### Suffix
+
+enum: ".js" | ".mjs" | ".cjs" | ".bs.js" | ".bs.mjs" | ".bs.cjs"
+
+### Reason
+
+| Parameter | JSON type | Remark | Implemented? |
+| --------- | --------- | ------ | :----------: |
+| react-jsx | number    |        |     [x]      |
+
+### Target-Item
+
+Not really usable by ReScript, likely to be removed.
+
+| Parameter | JSON type        | Remark | Implemented? |
+| --------- | ---------------- | ------ | :----------: |
+| kind      | Target-Item-Kind |        |     [_]      |
+| main      | string           |        |     [_]      |
+
+### Target-Item-Kind
+
+enum: "native" | "bytecode" | "js"
+
+### Group
+
+What is this even for? The spec says it is not even implemented in ReScript. Likely to be removed.
+
+| Parameter | JSON type | Remark | Implemented? |
+| --------- | --------- | ------ | :----------: |
+| name      | string    |        |     [_]      |
+| hierarchy | boolean   |        |     [_]      |

--- a/CompilerConfigurationSpec.md
+++ b/CompilerConfigurationSpec.md
@@ -132,9 +132,13 @@ enum: | "dce" | "exception" | "termination"
 
 | Parameter | JSON type     | Remark | Implemented? |
 | --------- | ------------- | ------ | :----------: |
-| module    | Module-Format |        |     [x]      |
+| module    | Module-Format |        |     [_]      |
 | in-source | boolean       |        |     [x]      |
 | suffix    | Suffix        |        |     [_]      |
+
+### Module-Format
+
+enum: "commonjs" | "es6" | "es6-global"
 
 ### Suffix
 

--- a/src/bsconfig.rs
+++ b/src/bsconfig.rs
@@ -1,5 +1,5 @@
-use serde::Deserialize;
-use std::fs;
+use serde::{Deserialize, Serialize};
+use std::{fmt, fs};
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(untagged)]
@@ -94,6 +94,55 @@ pub enum Namespace {
     String(String),
 }
 
+#[derive(Deserialize, Debug, Clone)]
+pub enum JsxMode {
+    #[serde(rename = "classic")]
+    Classic,
+    #[serde(rename = "automatic")]
+    Automatic,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub enum JsxModule {
+    #[serde(rename = "react")]
+    React,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum Suffix {
+    #[serde(rename = ".js")]
+    Js,
+    #[serde(rename = ".mjs")]
+    Mjs,
+    #[serde(rename = ".cjs")]
+    Cjs,
+    #[serde(rename = ".bs.js")]
+    BsJs,
+    #[serde(rename = ".bs.mjs")]
+    BsMjs,
+    #[serde(rename = ".bs.cjs")]
+    BsCjs,
+}
+
+impl fmt::Display for Suffix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_value(self).unwrap().as_str().unwrap()
+        )
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct JsxSpecs {
+    pub version: Option<i32>,
+    pub module: Option<JsxModule>,
+    pub mode: Option<JsxMode>,
+    #[serde(rename = "v3-dependencies")]
+    pub v3_dependencies: Option<Vec<String>>,
+}
+
 /// # bsconfig.json representation
 /// This is tricky, there is a lot of ambiguity. This is probably incomplete.
 #[derive(Deserialize, Debug, Clone)]
@@ -103,7 +152,7 @@ pub struct T {
     #[serde(rename = "package-specs")]
     pub package_specs: Option<OneOrMore<PackageSpec>>,
     pub warnings: Option<Warnings>,
-    pub suffix: Option<String>,
+    pub suffix: Option<Suffix>,
     #[serde(rename = "pinned-dependencies")]
     pub pinned_dependencies: Option<Vec<String>>,
     #[serde(rename = "bs-dependencies")]
@@ -116,6 +165,8 @@ pub struct T {
     pub bsc_flags: Option<Vec<OneOrMore<String>>>,
     pub reason: Option<Reason>,
     pub namespace: Option<Namespace>,
+    pub jsx: Option<JsxSpecs>,
+    pub uncurried: Option<bool>,
 }
 
 /// This flattens string flags

--- a/src/build_types.rs
+++ b/src/build_types.rs
@@ -67,6 +67,7 @@ pub struct BuildState {
     pub packages: AHashMap<String, Package>,
     pub module_names: AHashSet<String>,
     pub project_root: String,
+    pub root_config_name: String,
 }
 
 impl BuildState {
@@ -77,12 +78,17 @@ impl BuildState {
     pub fn get_module(&self, module_name: &str) -> Option<&Module> {
         self.modules.get(module_name)
     }
-    pub fn new(project_root: String, packages: AHashMap<String, Package>) -> Self {
+    pub fn new(
+        project_root: String,
+        root_config_name: String,
+        packages: AHashMap<String, Package>,
+    ) -> Self {
         Self {
             module_names: AHashSet::new(),
             modules: AHashMap::new(),
             packages: packages,
             project_root: project_root,
+            root_config_name: root_config_name,
         }
     }
     pub fn insert_module(&mut self, module_name: &str, module: Module) {

--- a/src/package_tree.rs
+++ b/src/package_tree.rs
@@ -378,3 +378,8 @@ pub fn make(filter: &Option<regex::Regex>, root_folder: &str) -> AHashMap<String
         });
     result
 }
+
+pub fn get_package_name(path: &str) -> String {
+    let bsconfig = read_bsconfig(&path);
+    bsconfig.name
+}


### PR DESCRIPTION
I also added a markdown file to keep track of all the bsconfig parameters.

i tried these changes on [rescript-mui](https://github.com/cca-io/rescript-mui), which uses the `.bs.js` suffix, ReScript 11 (uncurried mode) and JSX4 and it worked well.

But it may break something else...