### PR TITLE
Watcher / After build command

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -1111,7 +1111,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
 
     print!(
         "{} {} Building package tree...",
-        style("[1/6]").bold().dim(),
+        style("[1/7]").bold().dim(),
         TREE
     );
     let _ = stdout().flush();
@@ -1123,7 +1123,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
     println!(
         "{}\r{} {}Built package tree in {:.2}s",
         LINE_CLEAR,
-        style("[1/6]").bold().dim(),
+        style("[1/7]").bold().dim(),
         CHECKMARK,
         timing_package_tree_elapsed.as_secs_f64()
     );
@@ -1131,7 +1131,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
     let timing_source_files = Instant::now();
     print!(
         "{} {} Finding source files...",
-        style("[2/6]").bold().dim(),
+        style("[2/7]").bold().dim(),
         LOOKING_GLASS
     );
     let _ = stdout().flush();
@@ -1141,14 +1141,14 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
     println!(
         "{}\r{} {}Found source files in {:.2}s",
         LINE_CLEAR,
-        style("[2/6]").bold().dim(),
+        style("[2/7]").bold().dim(),
         CHECKMARK,
         timing_source_files_elapsed.as_secs_f64()
     );
 
     print!(
         "{} {} Cleaning up previous build...",
-        style("[3/6]").bold().dim(),
+        style("[3/7]").bold().dim(),
         SWEEP
     );
     let timing_cleanup = Instant::now();
@@ -1158,7 +1158,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
     println!(
         "{}\r{} {}Cleaned {}/{} {:.2}s",
         LINE_CLEAR,
-        style("[3/6]").bold().dim(),
+        style("[3/7]").bold().dim(),
         CHECKMARK,
         diff_cleanup,
         total_cleanup,
@@ -1171,7 +1171,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
     pb.set_style(
         ProgressStyle::with_template(&format!(
             "{} {} Parsing... {{spinner}} {{pos}}/{{len}} {{msg}}",
-            style("[4/6]").bold().dim(),
+            style("[4/7]").bold().dim(),
             CODE
         ))
         .unwrap(),
@@ -1186,7 +1186,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
             println!(
                 "{}\r{} {}Parsed {} source files in {:.2}s",
                 LINE_CLEAR,
-                style("[4/6]").bold().dim(),
+                style("[4/7]").bold().dim(),
                 CHECKMARK,
                 num_dirty_modules,
                 timing_ast_elapsed.as_secs_f64()
@@ -1198,7 +1198,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
             println!(
                 "{}\r{} {}Error parsing source files in {:.2}s",
                 LINE_CLEAR,
-                style("[4/6]").bold().dim(),
+                style("[4/7]").bold().dim(),
                 CROSS,
                 timing_ast_elapsed.as_secs_f64()
             );
@@ -1215,7 +1215,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
     println!(
         "{}\r{} {}Collected deps in {:.2}s",
         LINE_CLEAR,
-        style("[5/6]").bold().dim(),
+        style("[5/7]").bold().dim(),
         CHECKMARK,
         timing_deps_elapsed.as_secs_f64()
     );
@@ -1286,7 +1286,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
     pb.set_style(
         ProgressStyle::with_template(&format!(
             "{} {} Compiling... {{spinner}} {{pos}}/{{len}} {{msg}}",
-            style("[6/6]").bold().dim(),
+            style("[6/7]").bold().dim(),
             SWORDS
         ))
         .unwrap(),
@@ -1554,7 +1554,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
         println!(
             "{}\r{} {}Compiled {} modules in {:.2}s",
             LINE_CLEAR,
-            style("[6/6]").bold().dim(),
+            style("[6/7]").bold().dim(),
             CROSS,
             num_compiled_modules,
             compile_duration.as_secs_f64()
@@ -1567,7 +1567,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
         println!(
             "{}\r{} {}Compiled {} modules in {:.2}s",
             LINE_CLEAR,
-            style("[6/6]").bold().dim(),
+            style("[6/7]").bold().dim(),
             CHECKMARK,
             num_compiled_modules,
             compile_duration.as_secs_f64()
@@ -1575,7 +1575,13 @@ pub fn build(filter: &Option<regex::Regex>, path: &str) -> Result<BuildState, ()
     }
 
     let timing_total_elapsed = timing_total.elapsed();
-    println!("Done in {:.2}s", timing_total_elapsed.as_secs_f64());
+    println!(
+        "{}\r{} {}Finished Compilation in {:.2}s",
+        LINE_CLEAR,
+        style("[7/7]").bold().dim(),
+        CHECKMARK,
+        timing_total_elapsed.as_secs_f64()
+    );
 
     Ok(build_state)
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,0 +1,25 @@
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+
+pub fn run(command_string: String) {
+    let parsed_command = command_string.split_whitespace().collect::<Vec<&str>>();
+    let (command, params) = parsed_command.split_at(1);
+
+    let mut cmd = Command::new(command[0])
+        .args(params)
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("failed to execute process");
+
+    {
+        let stdout = cmd.stdout.as_mut().unwrap();
+        let stdout_reader = BufReader::new(stdout);
+        let stdout_lines = stdout_reader.lines();
+
+        for line in stdout_lines {
+            println!("{}", line.unwrap());
+        }
+    }
+
+    cmd.wait().unwrap();
+}

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,24 +1,55 @@
+use crate::helpers::emojis::*;
+use console::style;
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
+use std::time::Instant;
 
 pub fn run(command_string: String) {
+    let start_subcommand = Instant::now();
+
+    print!(
+        "{} {} Running subcommand... \n{}\n",
+        style("[...]").bold().dim(),
+        COMMAND,
+        style("────────"),
+    );
+
     let parsed_command = command_string.split_whitespace().collect::<Vec<&str>>();
     let (command, params) = parsed_command.split_at(1);
 
     let mut cmd = Command::new(command[0])
         .args(params)
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("failed to execute process");
 
     {
         let stdout = cmd.stdout.as_mut().unwrap();
+        let stderr = cmd.stderr.as_mut().unwrap();
+
         let stdout_reader = BufReader::new(stdout);
+        let stderr_reader = BufReader::new(stderr);
+
         let stdout_lines = stdout_reader.lines();
+        let std_err = stderr_reader.lines();
 
         for line in stdout_lines {
             println!("{}", line.unwrap());
         }
+
+        for line in std_err {
+            println!("{}", line.unwrap());
+        }
+
+        let subcommand_duration = start_subcommand.elapsed();
+        println!(
+            "{}\n{} {} Ran subcommand in {:.2}s",
+            style("────────"),
+            style("[...]").bold().dim(),
+            CHECKMARK,
+            subcommand_duration.as_secs_f64(),
+        );
     }
 
     cmd.wait().unwrap();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -7,6 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 pub mod emojis {
     use console::Emoji;
+    pub static COMMAND: Emoji<'_, '_> = Emoji("🏃 ", "");
     pub static TREE: Emoji<'_, '_> = Emoji("🌴 ", "");
     pub static SWEEP: Emoji<'_, '_> = Emoji("🧹 ", "");
     pub static LOOKING_GLASS: Emoji<'_, '_> = Emoji("🔍 ", "");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bsconfig;
 pub mod build;
 pub mod build_types;
 pub mod clean;
+pub mod cmd;
 pub mod helpers;
 pub mod logs;
 pub mod package_tree;


### PR DESCRIPTION
This is an issue when running things like a test watcher simultaniously
with Rewatch. Because of the amount of IO Rewacht produces, the watcher
in the secondary thread get's respawned over-and-over, making it produce
more IO than needed. This allows the user to pass in a subcommand to be
ran whenever the build has finished. IE:

```
rewatch watch . -a "yarn jest foo.test"
```

Or, when there are longer build times, alert the user that the build is
finished.

```
rewatch watch . -a "tput bel"
```

Effectively this means we have a way for the user to tap into the watcher, and spawn commands there, rather than relying on starting an additional watcher.