### PR TITLE
Improve logs with dependency cycles

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -1608,11 +1608,11 @@ pub fn build(filter: &Option<regex::Regex>, path: &str, no_timing: bool) -> Resu
             .map(|module_name| module_name.to_string())
             .collect::<AHashSet<String>>();
 
-            let cycle = helpers::detect_cycle_stack(&build_state.modules, not_compiled_modules);
+            let cycle_stack = helpers::detect_cycle_stack(&build_state.modules, not_compiled_modules);
 
-            match cycle {
-                Some(cycle) => {
-                    let error = format!("Dependency cycle detected: \n{}\n", cycle.join(" -> "));
+            match cycle_stack {
+                Some(cycle_stack) => {
+                    let error = format!("Dependency cycle detected: \n{}\n", cycle_stack.join(" -> "));
                     compile_errors.push_str(&error)
                 }
                 None => {


### PR DESCRIPTION
This is extracting the list of dependencies in a dependencies cycle and showing them to the user with the following format:
```
Dependency cycle detected: 
DepsA -> DepsA -> DepsC 
```
with `DepsC` having a dependency on `DepsA`. We could probably also print the initial module another time after `DepsC` to make it more clear.

The algorithm to detect the list of dependencies is DFS. I'm not aware of any pre-build implementation I could have reused, but happy to give it a try. 

[MISSING: testing]
 I'm not really sure what's are the best practice to cover this with tests, but can give it a try :)
