### PR TITLE
fix(watcher): adding sleep so CPU can schedule other work

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -15,6 +15,9 @@ async fn async_watch(
     after_build: Option<String>,
 ) -> notify::Result<()> {
     loop {
+        // We want to sleep for a little while so the CPU can schedule other work. That way we end
+        // up not burning CPU cycles.
+        Delay::new(Duration::from_millis(50)).await;
         let mut events: Vec<Event> = vec![];
         while !q.is_empty() {
             match q.pop() {


### PR DESCRIPTION
Basically we need to sleep on this loop so the CPU can schedule other work. It lowers the CPU usage from 100% to 0.1%.

The value `50ms` was arbitrarily chosen and I didn't had any noticeable lag from changing the file to building because of this.

Previously:
<img width="844" alt="image" src="https://github.com/rolandpeelen/rewatch/assets/18554242/c78c97b3-e03a-42d9-b9cc-9c807fbfc31f">



With this change:
<img width="986" alt="image" src="https://github.com/rolandpeelen/rewatch/assets/18554242/c0ebc4c1-0de9-4bf8-8714-a93ac67b9b55">
