### PR TITLE
adds allowed_parents attribute to bsconfig.json

### DIFF
--- a/src/bsconfig.rs
+++ b/src/bsconfig.rs
@@ -179,6 +179,9 @@ pub struct T {
     // this is a new feature of rewatch, and it's not part of the bsconfig.json spec
     #[serde(rename = "namespace-entry")]
     pub namespace_entry: Option<String>,
+    // this is a new feature of rewatch, and it's not part of the bsconfig.json spec
+    #[serde(rename = "allowed-parents")]
+    pub allowed_parents: Option<Vec<String>>,
 }
 
 /// This flattens string flags

--- a/src/build.rs
+++ b/src/build.rs
@@ -1186,6 +1186,10 @@ pub fn build(filter: &Option<regex::Regex>, path: &str, no_timing: bool) -> Resu
             .as_secs_f64()
     );
 
+    if !package_tree::valide_package_dependencies(&packages) {
+        return Err(());
+    }
+
     let timing_source_files = Instant::now();
     print!(
         "{} {} Finding source files...",


### PR DESCRIPTION
**Details**
Adds a new entry to the `bsconfig.json` called `allowed_parents` that restricts the packages with the current package as a dependency to a static list of values.

```
{
  ...
  "allowed_parents": Vec<String>
  ...
}
```

after creating the package tree during the build operation, we validate the dependencies, and in case the `allowed_parents` entry is defined and the current package is the `bs-dependencies` of another package, we will print the following error in the console:

```
Error the package *package1* is not allowed to have *package2*  as a dependency. Check the *allowed_parents* entry in the bsconfig.json
```

**Doubts**
- The format of the error message can be improved.
- In the initial solution I'm blocking the rest of the build process after an invalid dependency is detected, but I'm not sure if this is the correct approach.
- I've created a few tests on the file, but those tests are not part of the pipeline. Some unit test in the `queue.rs` file are breaking them.

