### PR TITLE
Don't read bsconfig for peer deps installed by parent packages

### DIFF
--- a/src/build/packages.rs
+++ b/src/build/packages.rs
@@ -38,6 +38,15 @@ impl Namespace {
 }
 
 #[derive(Debug, Clone)]
+struct Dependency {
+    name: String,
+    bsconfig: bsconfig::T,
+    path: String,
+    is_pinned: bool,
+    dependencies: Vec<Dependency>
+}
+
+#[derive(Debug, Clone)]
 pub struct Package {
     pub name: String,
     pub bsconfig: bsconfig::T,
@@ -164,14 +173,6 @@ fn get_source_dirs(source: bsconfig::Source, sub_path: Option<PathBuf>) -> AHash
     source_folders
 }
 
-fn get_package_dir(package_name: &str, is_root: bool) -> String {
-    if is_root {
-        "".to_string()
-    } else {
-        helpers::get_relative_package_path(&package_name, is_root)
-    }
-}
-
 fn read_bsconfig(package_dir: &str) -> bsconfig::T {
     let prefix = if package_dir == "" {
         "".to_string()
@@ -190,127 +191,158 @@ fn read_bsconfig(package_dir: &str) -> bsconfig::T {
 }
 
 /// # Make Package
-/// Given a directory that includes a bsconfig file, read it, and recursively find all other
-/// bsconfig files, and turn those into Packages as well.
-fn build_package<'a>(
-    map: &'a mut AHashMap<String, Package>,
-    bsconfig: bsconfig::T,
-    package_dir: &str,
-    project_root: &str,
-    is_pinned_dep: bool,
-    is_root: bool,
-) -> &'a mut AHashMap<String, Package> {
-    // let (package_dir, bsconfig) = read_bsconfig(package_name, project_root, is_root);
-    let copied_bsconfig = bsconfig.to_owned();
 
-    /* At this point in time we may have started encountering elements multiple times as there is
-     * no deduplication on the package level so far. Once we return this flat list of packages, do
-     * have this deduplication. From that point on, we can add the source files for every single
-     * one as that is an expensive operation IO wise and we don't want to duplicate that.*/
-    map.insert(copied_bsconfig.name.to_owned(), {
-        let source_folders = match bsconfig.sources.to_owned() {
-            bsconfig::OneOrMore::Single(source) => get_source_dirs(source, None),
-            bsconfig::OneOrMore::Multiple(sources) => {
-                let mut source_folders: AHashSet<bsconfig::PackageSource> = AHashSet::new();
-                sources
-                    .iter()
-                    .map(|source| get_source_dirs(source.to_owned(), None))
-                    .collect::<Vec<AHashSet<bsconfig::PackageSource>>>()
-                    .into_iter()
-                    .for_each(|source| source_folders.extend(source));
-                source_folders
-            }
-        };
-
-        let namespace_from_package = namespace_from_package_name(&bsconfig.name);
-        Package {
-            name: copied_bsconfig.name.to_owned(),
-            bsconfig: copied_bsconfig,
-            source_folders,
-            source_files: None,
-            namespace: match (bsconfig.namespace, bsconfig.namespace_entry) {
-                (Some(bsconfig::Namespace::Bool(false)), _) => Namespace::NoNamespace,
-                (None, _) => Namespace::NoNamespace,
-                (Some(bsconfig::Namespace::Bool(true)), None) => Namespace::Namespace(namespace_from_package),
-                (Some(bsconfig::Namespace::Bool(true)), Some(entry)) => Namespace::NamespaceWithEntry {
-                    namespace: namespace_from_package,
-                    entry: entry,
-                },
-                (Some(bsconfig::Namespace::String(str)), None) => match str.as_str() {
-                    "true" => Namespace::Namespace(namespace_from_package),
-                    namespace if namespace.is_case(Case::UpperFlat) => {
-                        Namespace::Namespace(namespace.to_string())
-                    }
-                    namespace => Namespace::Namespace(namespace.to_string().to_case(Case::Pascal)),
-                },
-                (Some(bsconfig::Namespace::String(str)), Some(entry)) => match str.as_str() {
-                    "true" => Namespace::NamespaceWithEntry {
-                        namespace: namespace_from_package,
-                        entry,
-                    },
-                    namespace if namespace.is_case(Case::UpperFlat) => Namespace::NamespaceWithEntry {
-                        namespace: namespace.to_string(),
-                        entry: entry,
-                    },
-                    namespace => Namespace::NamespaceWithEntry {
-                        namespace: namespace.to_string().to_case(Case::Pascal),
-                        entry,
-                    },
-                },
-            },
-            modules: None,
-            package_dir: package_dir.to_string(),
-            dirs: None,
-            is_pinned_dep: is_pinned_dep,
-            is_root,
-        }
-    });
-
-    bsconfig
+/// Given a bsconfig, reqursively finds all dependencies.
+/// 1. It starts with registering dependencies and
+/// prevents the operation for the ones which are already
+/// registerd for the parent packages. Especially relevant for peerDependencies.
+/// 2. In parallel performs IO to read the dependencies bsconfig and
+/// recursively continues operation for their dependencies as well.
+fn read_dependencies<'a>(
+    registered_dependencies_set: &'a mut AHashSet<String>,
+    parent_bsconfig: bsconfig::T,
+) -> Vec<Dependency> {
+    return parent_bsconfig
         .bs_dependencies
         .to_owned()
         .unwrap_or(vec![])
         .iter()
         .filter_map(|package_name| {
-            let package_dir = match PathBuf::from(get_package_dir(package_name, false)).canonicalize() {
-                Ok(dir) => dir.to_string_lossy().to_string(),
-                Err(e) => {
-                    print!(
-                        "{} {} Error building package tree (are node_modules up-to-date?)... \n More details: {}",
-                        style("[1/2]").bold().dim(),
-                        CROSS,
-                        e.to_string()
-                    );
-                    std::process::exit(2)
-                }
-            };
-
-            if !map.contains_key(package_name) {
-                Some(package_dir)
-            } else {
+            if registered_dependencies_set.contains(package_name) {
                 None
+            } else {
+                registered_dependencies_set.insert(package_name.to_owned());
+                Some(package_name.to_owned())
             }
         })
         .collect::<Vec<String>>()
-        // read all bsconfig files simultanously instead of blocking
+        // Read all bsconfig files in parallel instead of blocking
         .par_iter()
-        .map(|package_dir| (package_dir.to_owned(), read_bsconfig(package_dir)))
-        .collect::<Vec<(String, bsconfig::T)>>()
-        .iter()
-        .fold(map, |map, (package_dir, child_bsconfig)| {
-            build_package(
-                map,
-                child_bsconfig.to_owned(),
-                &package_dir,
-                &project_root,
-                bsconfig
-                    .pinned_dependencies
-                    .as_ref()
-                    .map(|p| p.contains(&child_bsconfig.name))
-                    .unwrap_or(false),
-                false,
-            )
-        })
+        .map(|package_name| {
+            let path =
+                match PathBuf::from(helpers::get_relative_package_path(package_name, false)).canonicalize() {
+                    Ok(dir) => dir.to_string_lossy().to_string(),
+                    Err(e) => {
+                        print!(
+                          "{} {} Error building package tree (are node_modules up-to-date?)... \n More details: {}",
+                          style("[1/2]").bold().dim(),
+                          CROSS,
+                          e.to_string()
+                        );
+                        std::process::exit(2)
+                    }
+                };
+
+            let bsconfig = read_bsconfig(&path);
+            let is_pinned = parent_bsconfig
+            .pinned_dependencies
+            .as_ref()
+            .map(|p| p.contains(&bsconfig.name))
+            .unwrap_or(false);
+
+            let dependencies = read_dependencies(&mut registered_dependencies_set.clone(),bsconfig.to_owned());
+
+            Dependency {
+              name: package_name.to_owned(),
+              bsconfig,
+              path,
+              is_pinned,
+              dependencies,
+            }
+        }) 
+        .collect::<Vec<Dependency>>();
+}
+
+fn flatten_dependencies(dependencies: Vec<Dependency>) -> Vec<Dependency> {
+    let mut flattened: Vec<Dependency> = Vec::new();
+    for dep in dependencies {
+        flattened.push(dep.clone());
+        let nested_flattened = flatten_dependencies(dep.dependencies);
+        flattened.extend(nested_flattened);
+    }
+    flattened
+}
+
+fn make_package (
+    bsconfig: bsconfig::T,
+    package_dir: &str,
+    is_pinned_dep: bool,
+    is_root: bool
+) -> Package {
+    let source_folders = match bsconfig.sources.to_owned() {
+        bsconfig::OneOrMore::Single(source) => get_source_dirs(source, None),
+        bsconfig::OneOrMore::Multiple(sources) => {
+            let mut source_folders: AHashSet<bsconfig::PackageSource> = AHashSet::new();
+            sources
+                .iter()
+                .map(|source| get_source_dirs(source.to_owned(), None))
+                .collect::<Vec<AHashSet<bsconfig::PackageSource>>>()
+                .into_iter()
+                .for_each(|source| source_folders.extend(source));
+            source_folders
+        }
+    };
+
+    let namespace_from_package = namespace_from_package_name(&bsconfig.name);
+    Package {
+        name: bsconfig.name.to_owned(),
+        bsconfig: bsconfig.to_owned(),
+        source_folders,
+        source_files: None,
+        namespace: match (bsconfig.namespace, bsconfig.namespace_entry) {
+            (Some(bsconfig::Namespace::Bool(false)), _) => Namespace::NoNamespace,
+            (None, _) => Namespace::NoNamespace,
+            (Some(bsconfig::Namespace::Bool(true)), None) => Namespace::Namespace(namespace_from_package),
+            (Some(bsconfig::Namespace::Bool(true)), Some(entry)) => Namespace::NamespaceWithEntry {
+                namespace: namespace_from_package,
+                entry: entry,
+            },
+            (Some(bsconfig::Namespace::String(str)), None) => match str.as_str() {
+                "true" => Namespace::Namespace(namespace_from_package),
+                namespace if namespace.is_case(Case::UpperFlat) => {
+                    Namespace::Namespace(namespace.to_string())
+                }
+                namespace => Namespace::Namespace(namespace.to_string().to_case(Case::Pascal)),
+            },
+            (Some(bsconfig::Namespace::String(str)), Some(entry)) => match str.as_str() {
+                "true" => Namespace::NamespaceWithEntry {
+                    namespace: namespace_from_package,
+                    entry,
+                },
+                namespace if namespace.is_case(Case::UpperFlat) => Namespace::NamespaceWithEntry {
+                    namespace: namespace.to_string(),
+                    entry: entry,
+                },
+                namespace => Namespace::NamespaceWithEntry {
+                    namespace: namespace.to_string().to_case(Case::Pascal),
+                    entry,
+                },
+            },
+        },
+        modules: None,
+        package_dir: package_dir.to_string(),
+        dirs: None,
+        is_pinned_dep: is_pinned_dep,
+        is_root,
+    }
+}
+
+fn read_packages(project_root: &str) -> AHashMap<String, Package> {
+    let root_bsconfig = read_bsconfig(project_root);
+
+    // Store all packages and completely deduplicate them
+    let mut map: AHashMap<String, Package> = AHashMap::new();
+    map.insert(root_bsconfig.name.to_owned(), make_package(root_bsconfig.to_owned(), project_root, false, true));
+
+    let mut registered_dependencies_set: AHashSet<String> = AHashSet::new();
+    let dependencies = flatten_dependencies(read_dependencies(&mut registered_dependencies_set, root_bsconfig.to_owned()));
+    dependencies.iter().for_each(|d| {
+      if !map.contains_key(&d.name) {
+        map.insert(d.name.to_owned(), make_package(d.bsconfig.to_owned(), &d.path, d.is_pinned, false));
+      }
+    });
+
+    return map;
 }
 
 /// `get_source_files` is essentially a wrapper around `read_structure`, which read a
@@ -411,13 +443,8 @@ fn extend_with_children(
 ///    interface files.
 /// The two step process is there to reduce IO overhead
 pub fn make(filter: &Option<regex::Regex>, root_folder: &str) -> AHashMap<String, Package> {
-    /* The build_package get's called recursively. By using extend, we deduplicate all the packages
-     * */
-    let mut map: AHashMap<String, Package> = AHashMap::new();
+    let map = read_packages(root_folder);
 
-    let package_dir = get_package_dir("", true);
-    let bsconfig = read_bsconfig(&package_dir);
-    build_package(&mut map, bsconfig, &package_dir, root_folder, true, true);
     /* Once we have the deduplicated packages, we can add the source files for each - to minimize
      * the IO */
     let result = extend_with_children(&filter, map);
@@ -746,23 +773,23 @@ pub fn validate_packages_dependencies(packages: &AHashMap<String, Package>) -> b
         ]
         .iter()
         .for_each(|(dependency_type, dependencies)| {
-            if let Some(unallowed_dependency_name) = get_unallowed_dependents(packages, package_name, dependencies) {
-                let empty_unallowed_deps = UnallowedDependency{
-                   bs_deps: vec![],
-                   pinned_deps: vec![],
-                   bs_dev_deps: vec![],
+            if let Some(unallowed_dependency_name) =
+                get_unallowed_dependents(packages, package_name, dependencies)
+            {
+                let empty_unallowed_deps = UnallowedDependency {
+                    bs_deps: vec![],
+                    pinned_deps: vec![],
+                    bs_dev_deps: vec![],
                 };
-                
+
                 let unallowed_dependency = detected_unallowed_dependencies.entry(String::from(package_name));
-                let value = unallowed_dependency
-                .or_insert_with(||empty_unallowed_deps);
+                let value = unallowed_dependency.or_insert_with(|| empty_unallowed_deps);
                 match dependency_type {
                     &"bs-dependencies" => value.bs_deps.push(String::from(unallowed_dependency_name)),
                     &"pinned-dependencies" => value.pinned_deps.push(String::from(unallowed_dependency_name)),
                     &"bs-dev-dependencies" => value.bs_dev_deps.push(String::from(unallowed_dependency_name)),
                     _ => (),
                 }
-            
             }
         });
     }
@@ -772,7 +799,7 @@ pub fn validate_packages_dependencies(packages: &AHashMap<String, Package>) -> b
             console::style("Error").red(),
             console::style(package_name).bold()
         );
-        
+
         vec![
             ("bs-dependencies", unallowed_deps.bs_deps.to_owned()),
             ("pinned-dependencies", unallowed_deps.pinned_deps.to_owned()),
@@ -792,9 +819,10 @@ pub fn validate_packages_dependencies(packages: &AHashMap<String, Package>) -> b
     let has_any_unallowed_dependent = detected_unallowed_dependencies.len() > 0;
 
     if has_any_unallowed_dependent {
-        println!("\nUpdate the {} value in the {} of the unallowed dependencies to solve the issue!",
-        console::style("unallowed_dependents").bold().dim(),
-        console::style("bsconfig.json").bold().dim() 
+        println!(
+            "\nUpdate the {} value in the {} of the unallowed dependencies to solve the issue!",
+            console::style("unallowed_dependents").bold().dim(),
+            console::style("bsconfig.json").bold().dim()
         )
     }
     return !has_any_unallowed_dependent;
@@ -805,7 +833,7 @@ mod test {
     use crate::bsconfig::Source;
     use ahash::{AHashMap, AHashSet};
 
-    use super::{Package, Namespace};
+    use super::{Namespace, Package};
 
     fn create_package(
         name: String,


### PR DESCRIPTION
I've started adding support for `pnpm`, and this is the first part of the changes. The first issue I've come across is that it can't resolve dependencies since compared to `npm`/`yarn`, they are resolved in a different way. I've tried to change how paths to dependencies are resolved for `pnpm` and got another problem with peer dependencies, which I'm trying to solve here.

Before I start, here's an example of how packages are stored in different package managers.
Let's say we have a project which depends on package `A`, and the package `A` depends on package `B`:
```
# npm 
node_modules/
  A/
  B/

# pnpm
node_modules/
  A/
    node_modules/
      B/
```

So, to get `bsconfig`s of all our dependencies is quite easy. We need to recursively traverse all dependencies to get children from their own `node_modules`. Before it would be just creating relative path from the root's `node_modules`.

But here's the case which did break. Let's take the `A` and `B` from above and say that they both depend on `C`, which is a peer dependency for `B`. Then it'll be:

```
# npm 
node_modules/
  A/
  B/
  C/

# pnpm
node_modules/
  A/
    node_modules/
      B/
      C/
```

You can see that the `C` is not a part of the `B`'s package `node_modules`, only `A`'s one. And since we still have the `C` package in `bsconfig` of `B` module and try to resolve it, I've got a case when we tried to find `C` in the `B/node_modules/C` and got an error.

So, to solve the problem, I've updated the deduplication logic to ignore packages that were already read by parent packages.

Here's the result:

Before
```
Passed: @rescript/react
Passed: rescript-relay
Passed: @glennsl/rescript-fetch
Passed: @carla/rescript-stdlib
Passed: rescript-schema
Passed: rescript-envsafe
Passed: rescript-webapi
Passed: @carla/rescript-shared
Passed: @dzakh/rescript-ava
Passed: @carla/rescript-sandbox
Ignored: @rescript/react
Passed: @dzakh/rescript-ava
Passed: rescript-schema
Ignored: rescript-schema
Ignored: @rescript/react
Ignored: rescript-schema
Ignored: @carla/rescript-stdlib
Ignored: @dzakh/rescript-ava
Ignored: rescript-webapi
Ignored: rescript-schema
Ignored: @carla/rescript-stdlib
```
After
```
Passed: @rescript/react
Passed: rescript-relay
Passed: @glennsl/rescript-fetch
Passed: @carla/rescript-stdlib
Passed: rescript-schema
Passed: rescript-envsafe
Passed: rescript-webapi
Passed: @carla/rescript-shared
Passed: @dzakh/rescript-ava
Passed: @carla/rescript-sandbox
Ignored: @dzakh/rescript-ava
Ignored: rescript-schema
Ignored: @rescript/react
Ignored: rescript-schema
Ignored: @carla/rescript-stdlib
Ignored: @dzakh/rescript-ava
Ignored: rescript-webapi
Ignored: rescript-schema
Passed: rescript-nodejs
Ignored: rescript-schema
Ignored: @carla/rescript-stdlib
Ignored: @rescript/react
```

I couldn't reproduce the race condition with `rescript-relay` trying to read `@rescript/react`, which is a peer, but you can still see that there are fewer duplicated packages passed to continue with the `IO` operation. 