### PR TITLE
:sparkles: - Allow individual compilation of workspace member

### DIFF
--- a/src/build/deps.rs
+++ b/src/build/deps.rs
@@ -80,7 +80,7 @@ pub fn get_deps(build_state: &mut BuildState, deleted_modules: &AHashSet<String>
                     .expect("Package not found");
                 let ast_path = helpers::get_ast_path(
                     &source_file.implementation.path,
-                    &module.package_name,
+                    &package.package_dir,
                     &build_state.project_root,
                     package.is_root,
                 );
@@ -96,7 +96,7 @@ pub fn get_deps(build_state: &mut BuildState, deleted_modules: &AHashSet<String>
                     Some(interface) => {
                         let iast_path = helpers::get_iast_path(
                             &interface.path,
-                            &module.package_name,
+                            &package.package_dir,
                             &build_state.project_root,
                             package.is_root,
                         );

--- a/src/build/logs.rs
+++ b/src/build/logs.rs
@@ -12,10 +12,10 @@ enum Location {
     Ocaml,
 }
 
-fn get_log_file_path(project_root: &str, subfolder: Location, name: &str, is_root: bool) -> String {
+fn get_log_file_path(project_root: &str, subfolder: Location, package_path: &str, is_root: bool) -> String {
     let build_folder = match subfolder {
-        Location::Bs => helpers::get_bs_build_path(project_root, name, is_root),
-        Location::Ocaml => helpers::get_build_path(project_root, name, is_root),
+        Location::Bs => helpers::get_bs_build_path(project_root, package_path, is_root),
+        Location::Ocaml => helpers::get_build_path(project_root, package_path, is_root),
     };
 
     build_folder.to_owned() + "/.compiler.log"
@@ -49,22 +49,33 @@ pub fn initialize(project_root: &str, packages: &AHashMap<String, Package>) {
         let _ = File::create(get_log_file_path(
             project_root,
             Location::Bs,
-            name,
+            &package.package_dir,
             package.is_root,
         ))
         .map(|file| write_to_log_file(file, &name, &format!("#Start({})\n", helpers::get_system_time())))
-        .expect(&("Cannot create compiler log for package ".to_owned() + name));
+        .expect(
+            &(format!(
+                "Cannot create compiler log for package {} in {}",
+                name, &package.package_dir
+            )
+            .to_owned()),
+        );
     })
 }
 
-pub fn append(project_root: &str, is_root: bool, name: &str, str: &str) {
+pub fn append(project_root: &str, is_root: bool, name: &str, package_path: &str, str: &str) {
     File::options()
         .append(true)
-        .open(get_log_file_path(project_root, Location::Bs, name, is_root))
+        .open(get_log_file_path(
+            project_root,
+            Location::Bs,
+            package_path,
+            is_root,
+        ))
         .map(|file| write_to_log_file(file, &name, str))
         .expect(
             &("Cannot write compilerlog: ".to_owned()
-                + &get_log_file_path(project_root, Location::Bs, name, is_root)),
+                + &get_log_file_path(project_root, Location::Bs, package_path, is_root)),
         );
 }
 
@@ -75,14 +86,19 @@ pub fn finalize(project_root: &str, packages: &AHashMap<String, Package>) {
             .open(get_log_file_path(
                 project_root,
                 Location::Bs,
-                name,
+                &package.package_dir,
                 package.is_root,
             ))
             .map(|file| write_to_log_file(file, &name, &format!("#Done({})\n", helpers::get_system_time())));
 
         let _ = std::fs::copy(
-            get_log_file_path(project_root, Location::Bs, name, package.is_root),
-            get_log_file_path(project_root, Location::Ocaml, name, package.is_root),
+            get_log_file_path(project_root, Location::Bs, &package.package_dir, package.is_root),
+            get_log_file_path(
+                project_root,
+                Location::Ocaml,
+                &package.package_dir,
+                package.is_root,
+            ),
         );
     })
 }

--- a/src/build/namespaces.rs
+++ b/src/build/namespaces.rs
@@ -25,7 +25,7 @@ pub fn gen_mlmap(
     depending_modules: &AHashSet<String>,
     root_path: &str,
 ) -> String {
-    let build_path_abs = helpers::get_build_path(root_path, &package.name, package.is_root);
+    let build_path_abs = helpers::get_build_path(root_path, &package.package_dir, package.is_root);
     // we don't really need to create a digest, because we track if we need to
     // recompile in a different way but we need to put it in the file for it to
     // be readable.
@@ -50,12 +50,12 @@ pub fn gen_mlmap(
     path.to_string()
 }
 
-pub fn compile_mlmap(package: &packages::Package, namespace: &str, root_path: &str) {
-    let build_path_abs = helpers::get_build_path(root_path, &package.name, package.is_root);
+pub fn compile_mlmap(package: &packages::Package, namespace: &str, root_path: &str, bsc_path: &str) {
+    let build_path_abs = helpers::get_build_path(root_path, &package.package_dir, package.is_root);
     let mlmap_name = format!("{}.mlmap", namespace);
     let args = vec!["-w", "-49", "-color", "always", "-no-alias-deps", &mlmap_name];
 
-    let _ = Command::new(helpers::get_bsc(&root_path))
+    let _ = Command::new(bsc_path)
         .current_dir(helpers::canonicalize_string_path(&build_path_abs).unwrap())
         .args(args)
         .output()

--- a/src/build/read_compile_state.rs
+++ b/src/build/read_compile_state.rs
@@ -54,7 +54,7 @@ pub fn read(build_state: &mut BuildState) -> CompileAssetsState {
     for package in build_state.packages.values() {
         let read_dir = fs::read_dir(std::path::Path::new(&helpers::get_build_path(
             &build_state.project_root,
-            &package.name,
+            &package.package_dir,
             package.is_root,
         )))
         .unwrap();


### PR DESCRIPTION
It's now possible to just compile a single package in a workspace, this will decrease compilation time for that purpose (no need to compile the whole workspace)