### PR TITLE
♻️ - Use package.path instead of manually constructing path part 2

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -91,7 +91,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str, no_timing: bool) -> Resu
     let _ = stdout().flush();
     let mut build_state = BuildState::new(project_root, root_config_name, packages);
     packages::parse_packages(&mut build_state);
-    logs::initialize(&build_state.project_root, &build_state.packages);
+    logs::initialize(&build_state.packages);
     let timing_source_files_elapsed = timing_source_files.elapsed();
     println!(
         "{}\r{} {}Found source files in {:.2}s",
@@ -158,7 +158,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str, no_timing: bool) -> Resu
             print!("{}", &err);
         }
         Err(err) => {
-            logs::finalize(&build_state.project_root, &build_state.packages);
+            logs::finalize(&build_state.packages);
             println!(
                 "{}\r{} {}Error parsing source files in {:.2}s",
                 LINE_CLEAR,
@@ -204,7 +204,7 @@ pub fn build(filter: &Option<regex::Regex>, path: &str, no_timing: bool) -> Resu
     );
     let compile_duration = start_compiling.elapsed();
 
-    logs::finalize(&build_state.project_root, &build_state.packages);
+    logs::finalize(&build_state.packages);
     pb.finish();
     clean::cleanup_after_build(&build_state);
     if compile_errors.len() > 0 {

--- a/src/build/deps.rs
+++ b/src/build/deps.rs
@@ -78,12 +78,7 @@ pub fn get_deps(build_state: &mut BuildState, deleted_modules: &AHashSet<String>
                 let package = build_state
                     .get_package(&module.package_name)
                     .expect("Package not found");
-                let ast_path = helpers::get_ast_path(
-                    &source_file.implementation.path,
-                    &package.package_dir,
-                    &build_state.project_root,
-                    package.is_root,
-                );
+                let ast_path = package.get_ast_path(&source_file.implementation.path);
 
                 let mut deps = get_dep_modules(
                     &ast_path,
@@ -94,12 +89,7 @@ pub fn get_deps(build_state: &mut BuildState, deleted_modules: &AHashSet<String>
 
                 match &source_file.interface {
                     Some(interface) => {
-                        let iast_path = helpers::get_iast_path(
-                            &interface.path,
-                            &package.package_dir,
-                            &build_state.project_root,
-                            package.is_root,
-                        );
+                        let iast_path = package.get_iast_path(&interface.path);
 
                         deps.extend(get_dep_modules(
                             &iast_path,

--- a/src/build/namespaces.rs
+++ b/src/build/namespaces.rs
@@ -23,9 +23,8 @@ pub fn gen_mlmap(
     package: &packages::Package,
     namespace: &str,
     depending_modules: &AHashSet<String>,
-    root_path: &str,
 ) -> String {
-    let build_path_abs = helpers::get_build_path(root_path, &package.package_dir, package.is_root);
+    let build_path_abs = package.get_build_path();
     // we don't really need to create a digest, because we track if we need to
     // recompile in a different way but we need to put it in the file for it to
     // be readable.
@@ -50,8 +49,8 @@ pub fn gen_mlmap(
     path.to_string()
 }
 
-pub fn compile_mlmap(package: &packages::Package, namespace: &str, root_path: &str, bsc_path: &str) {
-    let build_path_abs = helpers::get_build_path(root_path, &package.package_dir, package.is_root);
+pub fn compile_mlmap(package: &packages::Package, namespace: &str, bsc_path: &str) {
+    let build_path_abs = package.get_build_path();
     let mlmap_name = format!("{}.mlmap", namespace);
     let args = vec!["-w", "-49", "-color", "always", "-no-alias-deps", &mlmap_name];
 

--- a/src/build/parse.rs
+++ b/src/build/parse.rs
@@ -33,26 +33,10 @@ pub fn generate_asts(
                 SourceType::MlMap(_) => {
                     // probably better to do this in a different function
                     // specific to compiling mlmaps
-                    let path = helpers::get_mlmap_path(
-                        &build_state.project_root,
-                        &package.package_dir,
-                        &package
-                            .namespace
-                            .to_suffix()
-                            .expect("namespace should be set for mlmap module"),
-                        package.is_root,
-                    );
-                    let compile_path = helpers::get_mlmap_compile_path(
-                        &build_state.project_root,
-                        &package.package_dir,
-                        &package
-                            .namespace
-                            .to_suffix()
-                            .expect("namespace should be set for mlmap module"),
-                        package.is_root,
-                    );
+                    let path = package.get_mlmap_path();
+                    let compile_path = package.get_mlmap_compile_path();
                     let mlmap_hash = helpers::compute_file_hash(&compile_path);
-                    namespaces::compile_mlmap(&package, module_name, &build_state.project_root, bsc_path);
+                    namespaces::compile_mlmap(&package, module_name, bsc_path);
                     let mlmap_hash_after = helpers::compute_file_hash(&compile_path);
 
                     let is_dirty = match (mlmap_hash, mlmap_hash_after) {
@@ -143,13 +127,7 @@ pub fn generate_asts(
                                     }
                                     _ => (),
                                 }
-                                logs::append(
-                                    &build_state.project_root,
-                                    package.is_root,
-                                    &package.name,
-                                    &package.package_dir,
-                                    &err,
-                                );
+                                logs::append(package, &err);
                                 stderr.push_str(&err);
                             }
                         }
@@ -161,13 +139,7 @@ pub fn generate_asts(
                             }
                             _ => (),
                         }
-                        logs::append(
-                            &build_state.project_root,
-                            package.is_root,
-                            &package.name,
-                            &package.package_dir,
-                            &err,
-                        );
+                        logs::append(package, &err);
                         has_failure = true;
                         stderr.push_str(&err);
                     }
@@ -186,13 +158,7 @@ pub fn generate_asts(
                                     }
                                     _ => (),
                                 }
-                                logs::append(
-                                    &build_state.project_root,
-                                    package.is_root,
-                                    &package.name,
-                                    &package.package_dir,
-                                    &err,
-                                );
+                                logs::append(package, &err);
                                 stderr.push_str(&err);
                             }
                         }
@@ -208,13 +174,7 @@ pub fn generate_asts(
                             }
                             _ => (),
                         }
-                        logs::append(
-                            &build_state.project_root,
-                            package.is_root,
-                            &package.name,
-                            &package.package_dir,
-                            &err,
-                        );
+                        logs::append(package, &err);
                         has_failure = true;
                         stderr.push_str(&err);
                     }
@@ -239,7 +199,7 @@ fn generate_ast(
     workspace_root: Option<String>,
 ) -> Result<(String, Option<String>), String> {
     let file = &filename.to_string();
-    let build_path_abs = helpers::get_build_path(root_path, &package.package_dir, package.is_root);
+    let build_path_abs = package.get_build_path();
     let path = PathBuf::from(filename);
     let ast_extension = path_to_ast_extension(&path);
 

--- a/src/build/read_compile_state.rs
+++ b/src/build/read_compile_state.rs
@@ -20,7 +20,7 @@ pub fn read(build_state: &mut BuildState) -> CompileAssetsState {
                 let package = build_state.packages.get(&module.package_name).unwrap();
 
                 Some(
-                    PathBuf::from(&package.package_dir)
+                    PathBuf::from(&package.path)
                         .canonicalize()
                         .expect("Could not canonicalize")
                         .join(source_file.implementation.path.to_owned())
@@ -39,7 +39,7 @@ pub fn read(build_state: &mut BuildState) -> CompileAssetsState {
             .filter_map(|module| {
                 let package = build_state.packages.get(&module.package_name).unwrap();
                 module.get_interface().as_ref().map(|interface| {
-                    PathBuf::from(&package.package_dir)
+                    PathBuf::from(&package.path)
                         .canonicalize()
                         .expect("Could not canonicalize")
                         .join(interface.path.to_owned())
@@ -52,12 +52,7 @@ pub fn read(build_state: &mut BuildState) -> CompileAssetsState {
 
     // scan all ast files in all packages
     for package in build_state.packages.values() {
-        let read_dir = fs::read_dir(std::path::Path::new(&helpers::get_build_path(
-            &build_state.project_root,
-            &package.package_dir,
-            package.is_root,
-        )))
-        .unwrap();
+        let read_dir = fs::read_dir(std::path::Path::new(&package.get_build_path())).unwrap();
 
         for entry in read_dir {
             match entry {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -50,20 +50,6 @@ pub fn package_path(root: &str, package_name: &str, is_root: bool) -> String {
     }
 }
 
-pub fn get_build_path(root: &str, package_dir: &str, is_root: bool) -> String {
-    match is_root {
-        true => format!("{}/lib/ocaml", root),
-        false => format!("{}/lib/ocaml", package_dir),
-    }
-}
-
-pub fn get_bs_build_path(root: &str, package_path: &str, is_root: bool) -> String {
-    match is_root {
-        true => format!("{}/lib/bs", root),
-        false => format!("{}/lib/bs", package_path),
-    }
-}
-
 pub fn get_abs_path(path: &str) -> String {
     let abs_path_buf = PathBuf::from(path);
 
@@ -184,14 +170,12 @@ pub fn string_ends_with_any(s: &PathBuf, suffixes: &[&str]) -> bool {
 }
 
 pub fn get_compiler_asset(
+    package: &packages::Package,
     source_file: &str,
-    package_path: &str,
     namespace: &packages::Namespace,
-    root_path: &str,
     extension: &str,
-    is_root: bool,
 ) -> String {
-    get_build_path(root_path, package_path, is_root)
+    package.get_build_path()
         + "/"
         + &file_path_to_compiler_asset_basename(source_file, namespace)
         + "."
@@ -207,11 +191,9 @@ pub fn canonicalize_string_path(path: &str) -> Option<String> {
 
 pub fn get_bs_compiler_asset(
     source_file: &str,
-    package_path: &str,
+    package: &packages::Package,
     namespace: &packages::Namespace,
-    root_path: &str,
     extension: &str,
-    is_root: bool,
 ) -> String {
     let namespace = match extension {
         "ast" | "iast" => &packages::Namespace::NoNamespace,
@@ -220,7 +202,7 @@ pub fn get_bs_compiler_asset(
 
     let dir = std::path::Path::new(&source_file).parent().unwrap();
 
-    std::path::Path::new(&get_bs_build_path(root_path, &package_path, is_root))
+    std::path::Path::new(&package.get_bs_build_path())
         .join(dir)
         .join(file_path_to_compiler_asset_basename(source_file, namespace) + extension)
         .to_str()
@@ -236,36 +218,6 @@ pub fn get_namespace_from_module_name(module_name: &str) -> Option<String> {
 
 pub fn is_interface_ast_file(file: &str) -> bool {
     file.ends_with(".iast")
-}
-
-pub fn get_mlmap_path(root_path: &str, package_path: &str, namespace: &str, is_root: bool) -> String {
-    get_build_path(root_path, package_path, is_root) + "/" + namespace + ".mlmap"
-}
-
-pub fn get_mlmap_compile_path(root_path: &str, package_path: &str, namespace: &str, is_root: bool) -> String {
-    get_build_path(root_path, package_path, is_root) + "/" + namespace + ".cmi"
-}
-
-pub fn get_ast_path(source_file: &str, package_path: &str, root_path: &str, is_root: bool) -> String {
-    get_compiler_asset(
-        source_file,
-        package_path,
-        &packages::Namespace::NoNamespace,
-        root_path,
-        "ast",
-        is_root,
-    )
-}
-
-pub fn get_iast_path(source_file: &str, package_path: &str, root_path: &str, is_root: bool) -> String {
-    get_compiler_asset(
-        source_file,
-        package_path,
-        &packages::Namespace::NoNamespace,
-        root_path,
-        "iast",
-        is_root,
-    )
 }
 
 pub fn read_lines(filename: String) -> io::Result<io::Lines<io::BufReader<fs::File>>> {


### PR DESCRIPTION
It's a continuation of the change https://github.com/rolandpeelen/rewatch/commit/1647b2a6780ada2a360a574979d558c52f548ba1

I recreated the changes of the PR https://github.com/rolandpeelen/rewatch/pull/84, because it was easier than solving merge conflicts. Also, I didn't include the change where I start resolving `path` differently to support pnpm, I want to do it in a separate PR, since this one is already quite big.