### PR TITLE
package.json name different from module name cause panic

### DIFF
--- a/src/build/packages.rs
+++ b/src/build/packages.rs
@@ -476,7 +476,7 @@ fn read_packages(
     dependencies.iter().for_each(|d| {
         if !map.contains_key(&d.name) {
             let package = make_package(d.config.to_owned(), &d.path, d.is_pinned, false);
-            map.insert(package.name.to_string(), package);
+            map.insert(d.name.to_string(), package);
         }
     });
 


### PR DESCRIPTION
Hey!
I started getting some issues when bumping from version `1.0.9` to `1.2.2`.
We're currently importing this package in our codebase (monorepo):
https://github.com/teamwalnut/rescript-urql
Which has a `rescript-urql` name in the [`package.json`](https://github.com/teamwalnut/rescript-urql/blob/main/package.json) but a different name `@urql/rescript` in the [`bsconfig.json`](https://github.com/teamwalnut/rescript-urql/blob/main/bsconfig.json#L2) 

When the package is resolved, it's stored with `rescript-urql` as a key, but when resolving the dependencies in our project, we reference the `bsconfig.json` name of the module, so `@urql/rescript`, causing a:
```
thread '<unnamed>' panicked at src/build/compile.rs:568:17:
Expected to find dependent package @urql/rescript of <my-package>
```

I can change the `package.json` name for that project, but I'm not sure if that's the correct behaviour and we should instead rely always only on the name in the `bsconfig/rescript.json` 🤔 

If needed, I can try creating a small environment with the issue or add some tests.
Let me know wdyt 🙏 
